### PR TITLE
Imlplement rpc function

### DIFF
--- a/lib/supabase/postgrest/behaviour.ex
+++ b/lib/supabase/postgrest/behaviour.ex
@@ -14,4 +14,9 @@ defmodule Supabase.PostgREST.Behaviour do
   @callback execute(Request.t()) :: Supabase.result(term)
   @callback execute_to(Request.t(), module) :: Supabase.result(term)
   @callback execute_to_finch_request(Request.t()) :: Finch.Request.t()
+
+  @callback rpc(Client.t(), function_name, arguments, options) :: Request.t()
+            when function_name: String.t(),
+                 arguments: map,
+                 options: list({:head | :get, boolean} | {:count, :exact | :planned | :estimated})
 end

--- a/lib/supabase/postgrest/error.ex
+++ b/lib/supabase/postgrest/error.ex
@@ -3,11 +3,12 @@ defmodule Supabase.PostgREST.Error do
 
   alias Supabase.Fetcher.Request
   alias Supabase.Fetcher.Response
+  alias Supabase.HTTPErrorParser
 
   @behaviour Supabase.Error
 
   @impl true
-  def from(%Response{body: body}, %Request{} = ctx) do
+  def from(%Response{body: body}, %Request{} = ctx) when is_map(body) do
     metadata = Supabase.Error.make_default_http_metadata(ctx)
 
     metadata =
@@ -23,5 +24,9 @@ defmodule Supabase.PostgREST.Error do
       service: :database,
       metadata: metadata
     )
+  end
+
+  def from(%Response{} = resp, %Request{} = ctx) do
+    HTTPErrorParser.from(resp, ctx)
   end
 end


### PR DESCRIPTION
## Problem

Library was missing the `rpc` function to perform postgresql function calls.

## Solution

Implement the `rpc` function that acceps a `Supabase.Client`, the function name and args and optional config.

It can also be extended and piplined to `Supabase.PostgREST.FilterBuilder` functions.

## Rationale

N/A
